### PR TITLE
Merge in tools for managing repository updates.

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,1 @@
+tools/.vagrant

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../", "/mnt/builds"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.define "default", primary: true do |node|
+    # debian/contrib-stretch64 includes the vboxsf guest additions
+    node.vm.box = "debian/contrib-stretch64"
+    node.vm.provision "shell", inline: <<-END
+        apt-get update
+        apt-get upgrade
+        apt-get install apt-utils git
+    END
+  end 
+end

--- a/tools/dedupdeb
+++ b/tools/dedupdeb
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+TOOLS=$(cd $(dirname $0) && pwd)
+if [ -n "$1" ]; then
+    cd "$1"
+fi
+
+names=$(ls | grep '\.deb' | sed -e 's/_.*//' | sort | uniq)
+
+for name in $names; do
+    last=$(ls -t $name*.deb | head -1)
+    second_last=$(ls -t $name*.deb | head -2 | tail -1)
+    echo "checking ${last} <> ${second_last}"
+    if [ "$last" != "$second_last" ] && $TOOLS/diffdeb $last $second_last; then
+        echo "-> removing $last (no substantive changes from $second_last)"
+        rm $last
+    fi
+done

--- a/tools/diffdeb
+++ b/tools/diffdeb
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+a=$1
+b=$2
+if [ "$b" = "" ]; then
+    echo "Usage: $0 <file1.deb> <file2.deb>"
+    echo "Exits with status 0 if two .deb files are identical in all aspects"
+    echo "except for the declared version number ("Version:") in the control"
+    echo "file.  Otherwise exits with status 1."
+    exit 1
+fi
+
+TAR=$(which gtar || which tar)  # we need GNU tar for a proper comparison
+atmp=/tmp/diffdeb.$$.1
+btmp=/tmp/diffdeb.$$.2
+trap 'rm -rf $atmp $btmp' EXIT
+
+# Unpacks a .deb file into a directory ready for comparison.  The file named
+# "deb" is destructively unpacked into the current directory.  The final
+# directory contains the original data.tar.gz, uncompressed to data.tar
+# (which is compared directly, thus comparing timestamps, permissions,
+# symlinks, etc.) and control.tar, which is a repacking of control.tar.gz
+# except with the control file edited to remove the Version line.
+function unpack_and_remove_version() {
+    # Unpack deb -> control.tar.gz, data.tar.gz, debian-binary
+    ar x deb
+    rm deb
+
+    # Unzip data.tar to remove the gzip timestamp from the header
+    gunzip data.tar.gz
+
+    # Unpack control.tar.gz and delete the "Version:" line
+    mkdir control
+    cd control
+    $TAR xfz ../control.tar.gz
+    grep -v '^Version: ' control > control.unversioned
+    touch -t 197001010000 control.unversioned
+    rm control ../control.tar.gz
+    $TAR cf ../control.tar *
+}
+
+mkdir -p $atmp $btmp
+cp $a $atmp/deb
+cp $b $btmp/deb
+
+cd $atmp
+unpack_and_remove_version
+cd $btmp
+unpack_and_remove_version
+
+diff -q -r $atmp $btmp >/dev/null

--- a/tools/fetch_circleci_artifacts
+++ b/tools/fetch_circleci_artifacts
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+import sys, json, os, os.path, urllib.request, fnmatch
+
+def usage():
+    print("""
+Usage: fetch_circleci_artifacts <project> <branch> [<glob>] [<token>]
+
+Fetches all artifacts matching a particular filename glob from the latest
+CircleCI build for the given Github project and branch to the current
+directory. Prints the names of all files fetched.
+
+<project> should be of the form '<username>/<repo>'.
+
+<glob> defaults to '*'.
+
+If <token> is not set, the script will look in the $CIRCLECI_API_TOKEN
+environment variable.
+""")
+    sys.exit(-1)
+
+latest_artifacts = \
+    "https://circleci.com/api/v1.1/project/github/{project}/latest/artifacts?" + \
+        "circle-token={token}&branch={branch}&filter=successful"
+
+if len(sys.argv) < 3:
+    usage()
+
+project, branch = sys.argv[1:3]
+match = sys.argv[3] if len(sys.argv) > 3 else "*"
+token = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("CIRCLECI_API_TOKEN")
+
+if not all((token, match, branch)):
+    usage()
+
+query = latest_artifacts.format(token=token, project=project, branch=branch)
+request = urllib.request.Request(query, headers={"Accept": "application/json"})
+with urllib.request.urlopen(request) as response:
+    content = response.read()
+    artifacts = json.loads(content.decode())
+    for artifact in artifacts:
+        if fnmatch.fnmatch(artifact["path"], match):
+            filename = os.path.basename(artifact["path"])
+            urllib.request.urlretrieve(artifact["url"], filename)
+            print(filename)

--- a/tools/index_debs
+++ b/tools/index_debs
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2015, 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+set -e
+
+if [ "$1" = "-h" -o -z "$1" -o -z "$2" ]; then
+    echo "Usage: $0 <repository-dir> <suite>"
+    echo
+    echo "Creates or updates the Release and Package indexes for the pool"
+    echo "of .deb files located at the given directory."
+    exit 1
+fi
+
+repo=$1
+suite=$2
+
+# This is a slow operation; each index takes a couple of minutes to build.
+cd $repo
+rm -rf dists/${suite}
+for arch in i386 amd64 all; do
+    echo "Indexing packages for architecture '$arch'..."
+    packages=dists/${suite}/main/binary-$arch/Packages
+    mkdir -p $(dirname $packages)
+    apt-ftparchive --arch $arch packages ${suite} > $packages
+done
+
+# Create the overall index of indexes.
+release=dists/${suite}/Release
+cat <<END > $release
+Origin: Buendia
+Label: Buendia Debian Packages
+Architectures: all
+Components: main
+Description: Buendia Debian Packages
+END
+
+echo "Suite: ${suite}" >> $release
+
+apt-ftparchive release dists/${suite} >>$release
+
+ls -l $(find dists -type f)
+du -d 0
+echo "Done."

--- a/tools/update_apt_archive
+++ b/tools/update_apt_archive
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+set -e
+
+if [ "$1" = "-h" -o -z "$1" -o -z "$2" -o -z "$CIRCLECI_API_TOKEN" ]; then
+    echo "Usage: $0 <repository-dir> <branch>"
+    echo
+    echo "Updates the apt archive in projectbuendia/builds with the latest"
+    echo "CircleCI build artifacts for a given branch of the"
+    echo "projectbuendia/buendia project."
+    echo
+    echo "<branch> can be either 'master' or 'dev'."
+    echo
+    echo "CIRCLECI_API_TOKEN must be set in the environment and"
+    echo "~/.gitconfig must be set up, or this script will fail."
+    exit 1
+fi
+
+repo=$1
+branch=$2
+tools=$(cd $(dirname $0) && pwd)
+project=projectbuendia/buendia
+
+if [ "$branch" = "master" ]; then
+    suite=stable
+elif [ "$branch" = "dev" ]; then
+    suite=unstable
+else
+    echo "Branch must be either 'master' or 'dev'!"
+    exit 1
+fi
+
+if [ ! -r ~/.gitconfig ]; then
+    echo "~/.gitconfig is missing; you need this to commit updates."
+    exit 1
+fi
+
+echo "- Fetching build artifacts for ${branch}"
+mkdir -p $repo/$suite
+cd $repo/$suite
+$tools/fetch_circleci_artifacts $project $branch '*.deb'
+
+echo
+echo "- De-duplicating packages in ${suite}"
+cd ..
+$tools/dedupdeb $suite
+
+echo
+echo "- Indexing packages in ${suite}"
+$tools/index_debs . $suite
+
+echo
+echo "- Committing changes to git"
+git add $suite
+git add dists/$suite
+if [ -n "$CI" ]; then
+    git commit -m "Automated update from CircleCI build #${CIRCLECI_BUILD_NUM}"
+else
+    git commit
+fi
+
+echo
+echo "- Pushing changes to Github"
+#git push --all

--- a/tools/update_apt_archive
+++ b/tools/update_apt_archive
@@ -71,4 +71,4 @@ fi
 
 echo
 echo "- Pushing changes to Github"
-#git push --all
+git push --all


### PR DESCRIPTION
I've brought these tools into this repo, rather than managing them in the buendia repo, mostly to try to split off the problems of building apt repositories in Git repositories in CI into its own problem space.

* `dedupdeb` and `diffdeb` are imported from [projectbuendia/buendia](https://github.com/projectbuendia/buendia/tree/dev/tools)
* `index_debs` is based on [buendia-pkgserver-index-debs](https://github.com/projectbuendia/buendia/blob/e3b2cee174/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-debs) from the `buendia-pkgserver` package in projectbuendia/buendia, but allows for indexing multiple suites (i.e. 'stable' and 'unstable')
* `fetch_circleci_artifacts` is a Python script that fetches the latest artifacts for a given branch from CircleCI
* `update_apt_archive` connects all the moving parts and performs the `git add/commit/push` dance